### PR TITLE
including unistd.h under linux

### DIFF
--- a/source/FileWatcherLinux.cpp
+++ b/source/FileWatcherLinux.cpp
@@ -31,6 +31,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <errno.h>
+#include <unistd.h>
 #include <sys/inotify.h>
 
 #define BUFF_SIZE ((sizeof(struct inotify_event)+FILENAME_MAX)*1024)


### PR DESCRIPTION
because the "read" call below was "undefined" (compilation error) on my ubuntu machine - Ubuntu 15.10 g++ 5.2