### PR TITLE
Fixed undefined behavior when removing watchers on Windows

### DIFF
--- a/source/FileWatcherWin32.cpp
+++ b/source/FileWatcherWin32.cpp
@@ -129,7 +129,7 @@ namespace FW
 
 			CloseHandle(pWatch->mOverlapped.hEvent);
 			CloseHandle(pWatch->mDirHandle);
-			delete pWatch->mDirName;
+			delete [] pWatch->mDirName;
 			HeapFree(GetProcessHeap(), 0, pWatch);
 		}
 	}


### PR DESCRIPTION
On Windows, in addWatch we are using new TCHAR[] to allocate the directory name array, but we are using 
delete pWatch->mDirName. 
According to this answer https://stackoverflow.com/a/2425749, allocating with new[], but using a single object delete is undefined behavior.
